### PR TITLE
feat: add partial git-clone task

### DIFF
--- a/tasks/git-clone/git-clone-env-pr-partial.yaml
+++ b/tasks/git-clone/git-clone-env-pr-partial.yaml
@@ -1,0 +1,72 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  creationTimestamp: null
+  name: git-clone-pr
+spec:
+  stepTemplate:
+    env:
+      - name: HOME
+        value: /tekton/home
+    envFrom:
+      - secretRef:
+          name: jx-boot-job-env-vars
+          optional: true
+    name: ""
+    resources: {}
+  steps:
+    - envFrom:
+        - secretRef:
+            name: jx-boot-job-env-vars
+            optional: true
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.27.0
+      name: git-clone-partial
+      resources: {}
+      script: |
+        #!/bin/sh
+        export SUBDIR="source"
+        echo "git cloning url: $REPO_URL version $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
+        git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
+        git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
+        git config --global credential.helper store
+        # Use a treeless clone to checkout only the desired commit
+        # Useful for large git repositories using single-build pipelines
+        git clone  --filter=tree:0 --no-checkout "$REPO_URL" "$SUBDIR"
+        cd $SUBDIR
+        git fetch origin $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
+        git checkout $(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
+        git branch
+        git reset --hard $PULL_PULL_SHA
+        echo "checked out revision: $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
+      workingDir: /workspace
+    - envFrom:
+        - secretRef:
+            name: jx-boot-job-env-vars
+            optional: true
+      image: ghcr.io/jenkins-x/jx-boot:3.10.154
+      name: git-merge
+      resources: {}
+      script: |
+        #!/usr/bin/env sh
+        counter=0
+        # Since a previous rebase can change the initial state of the branch, a successive rebase attempt can result in a conflict due to
+        # the previous regeneration commit attempting to be picked ontop of a different initial state of the PR's branch. Thus, this retry
+        # logic attempts to remove the latest regeneration commit and attempt the rebase again upon such conflicts.
+        until [ "$counter" -eq 3 ]; do
+          # lets avoid git rebase/merge conflicts on promotions
+          # '-r' to avoid unexpected conflicts (e.g. rename/rename) when trying to rebase commits sharing the same base commit.
+          # Preserving the merge commits thus ensures commits are always applied on top of their original base branch before being
+          # merged back into the rebased branch.
+         jx gitops git merge --rebase --merge-arg "-Xtheirs -r" && exit 0
+          counter=$((counter+1))
+          git rebase --abort
+          if git log -1 --pretty=%B | grep -i regenerate; then
+            git reset --hard HEAD~1
+          fi
+        done
+        exit 1
+      workingDir: /workspace/source
+  workspaces:
+    - description: The git repo will be cloned onto the volume backing this workspace
+      mountPath: /workspace
+      name: output


### PR DESCRIPTION
`tasks/git-clone/git-clone-env-pr-partial.yaml` generates a [treeless clone](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone) of the target git repository, using `git clone --filter=tree:0 --no-checkout`.

Can provide significant speed improvements for single-use build pipelines, especially for repositories with long histories.